### PR TITLE
oni-san

### DIFF
--- a/Apache2_modoki.html
+++ b/Apache2_modoki.html
@@ -152,7 +152,7 @@
                                     </td>
                                     <td align="right">
                                         {block:Caption}
-                                            {PhotoAlt}
+                                            {Caption}
                                         {/block:Caption}
                                     </td>
                                     <td>
@@ -170,14 +170,12 @@
         </table>
 
         <address>
-            <script type="text/javascript">
-                str = '{text:Bottom Strings}';
-                if (str) {
-                    document.write(str);
-                } else {
-                    document.write('Tumblr/Apache2_modoki at tumblr.com Port 80');
-                }
-            </script>
+            {block:IfBottomStrings}
+                {text:Bottom Strings}
+            {/block:IfBottomStrings}
+            {block:IfNotBottomStrings}
+                Tumblr/Apache2_modoki at tumblr.com Port 80
+            {/block:IfNotBottomStrings}
         </address>
 
         {block:PreviousPage}


### PR DESCRIPTION
- Photosetパーマリンク内のCaptionが表示されない問題を修正
  - ![2014-11-16 21-30-57](https://cloud.githubusercontent.com/assets/4990822/5061428/f6d69198-6dd7-11e4-8e1a-bde9f27a1402.png)
- BottomStringsの判定をjavascriptからTumblr標準の機能へ変更
  - 見た目に変化なし
  - jsを減らしたかった
